### PR TITLE
Fixes encoding issues.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 var request = require('request');
 var cheerio = require('cheerio');
 var tidy = require('htmltidy').tidy;
+var windows1252 = require('windows-1252');
 
 var getMenu = function(cb) {
-    request('http://dagskammtur.is/matsedill.htm', function(error, res, body) {
+    request({url: 'http://dagskammtur.is/matsedill.htm', encoding: 'binary'}, function(error, res, body) {
+        body = windows1252.decode(body);
         tidy(body, function(err, html) {
             var $ = cheerio.load(html);
             var data = [];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "cheerio": "^0.18.0",
     "htmltidy": "0.0.6",
-    "request": "^2.53.0"
+    "request": "^2.53.0",
+    "windows-1252": "^0.1.2"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This fix will handle the encoding issues we've been having. The reason for the errors turned out to be because the dagskammtur.is page is saved in windows-1252 encoding and request doesn't handle it (and they aren't sending the appropriate headers to notify anybody).

This patch will request the site in binary and convert that to windows-1252 encoding before passing it on to the callback.

cc/ @stebbib 
